### PR TITLE
ch6: 대재앙 시뮬레이션 추가

### DIFF
--- a/Java-Practice/src/main/java/com/moonz/javapractice/crackingCodingInterview/ch6/대재앙.java
+++ b/Java-Practice/src/main/java/com/moonz/javapractice/crackingCodingInterview/ch6/대재앙.java
@@ -1,0 +1,34 @@
+package com.moonz.javapractice.crackingCodingInterview.ch6;
+import java.util.Random;
+
+public class 대재앙 {
+    public static void main(String[] args) {
+        System.out.println(getPercentOfNFamilies(100));
+    }
+    static double getPercentOfNFamilies(int n) {
+        int totalGirlCnt = 0;
+        int totalBoyCnt = 0;
+        for (int i=0; i<n; i++) {
+            int[] genders = runOneFamily();
+            totalGirlCnt += genders[0];
+            totalBoyCnt += genders[1];
+        }
+        return (double)totalGirlCnt / ( totalGirlCnt + totalBoyCnt);
+    }
+
+    static int[] runOneFamily() {
+        Random random = new Random();
+        int boyCnt = 0;
+        int girlCnt = 0;
+        //여자 출산까지
+        while (girlCnt == 0) {
+            if (random.nextBoolean()) {   // boolean형 난수(0,1) 반환
+                girlCnt++;
+            }
+            else {
+                boyCnt++;
+            }
+        }
+        return new int[]{girlCnt, boyCnt};
+    }
+}


### PR DESCRIPTION
## 문제
대재앙 이후에 여왕은 출산율 때문에 근심이 이만저만이 아니다. 그래서 그녀는 모든 가족은 여자아이 하나를 낳거나 어마어마한 벌금을 내야 한다는 법령을 만들어 발표했다. 만약 모든 가족이 이 정책을 따른다면 (즉, 여자아이 한 명을 낳을 때 까지 아이를 계속 낳는다면) 다음 세대의 남녀 비율은 어떻게 되겠는가? 남자 혹은 여자를 임신할 확률은 같다고 가정한다. 논리적으로 이 문제를 푼 뒤에 컴퓨터로 시뮬레이션해 보라.

## 문제 이해
모든 가족이 정책을 따를 때, 남녀비율을 구하라.

## 시뮬레이션
- N개의 가족의 확률을 구하기 위해, N번 호출하면서 (random 라이브러리에 따른) 남녀 수를 반환받는다.
- 해당 수로 확률을 구해서 반환한다.