### PR TITLE
CTCI: 7-10. 지뢰찾기 게임

### DIFF
--- a/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/Board.java
+++ b/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/Board.java
@@ -1,0 +1,179 @@
+package com.moonz.javapractice.CrackingCodingInterview.ch7.prob10;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Random;
+
+public class Board {
+    private final int rowLen;
+    private final int colLen;
+    private Cell[][] cells;
+    private Cell[] bombs;   // 지뢰 정보를 갖고 있을 배열
+    private final int bombCnt;
+    private int unexposedNonBombCnt;
+    private static final int[][] ADJ_DIRECTIONS = {
+            {-1, -1}, {-1, 0}, {-1, 1},
+            {0, -1}, {0, 1},
+            {1, -1}, {1, 0}, {1, 1}
+    };
+
+    public Board(int r, int c, int b) {
+        rowLen = r;
+        colLen = c;
+        bombCnt = b;
+        unexposedNonBombCnt = r * c - bombCnt;
+        initBoard();
+        shuffleBoard();
+        numberingCells();
+    }
+
+    /**
+     * Board 초기화
+     */
+    public void initBoard() {
+        cells = new Cell[rowLen][colLen];
+        bombs = new Cell[bombCnt];
+        // 셀 init
+        for (int r = 0; r < rowLen; r++) {
+            for (int c = 0; c < colLen; c++) {
+                cells[r][c] = new Cell(r, c);
+            }
+        }
+        // 지뢰 init : 랜덤 섞기 전, [0번째 열, 값을 계산한 행]에 지뢰 두기
+        for (int i = 0; i < bombCnt; i++) {
+            int r = i / colLen;
+            int c = (i - r * colLen) % colLen;
+            bombs[i] = cells[r][c];
+            bombs[i].setBomb(true);
+        }
+    }
+
+    /**
+     * 지뢰 랜덤 섞기
+     * - 기존 방식이 이해되지 않아서, Random 클래스 이용해서 진행..
+     */
+    public void shuffleBoard() {
+        int cellCnt = rowLen * colLen;
+        Random random = new Random();
+        for (int i = 0; i < cellCnt; i++) {
+            int row1 = random.nextInt(rowLen);
+            int col1 = random.nextInt(colLen);
+
+            int row2 = random.nextInt(rowLen);
+            int col2 = random.nextInt(colLen);
+
+            if (row1 != row2 || col1 != col2) {
+                Cell cell1 = cells[row1][col1];
+                Cell cell2 = cells[row2][col2];
+                cells[row1][col1] = cell2;
+                cells[row2][col2] = cell1;
+                cell1.setRowCol(row2, col2);
+                cell2.setRowCol(row1, col1);
+                System.out.println("cell2의 (r,c): (" + row2 + ", " + col2 + ")");
+                System.out.println("cell1의 (r,c): (" + row1 + ", " + col1 + ")");
+            }
+        }
+    }
+
+    /**
+     * 인접 지뢰 수만큼 넘버링
+     */
+    public void numberingCells() {
+        // 지뢰 기준으로 순환
+        for (Cell curr : bombs) {
+            for (int[] adjDirection : ADJ_DIRECTIONS) {
+                int adjR = curr.getRow() + adjDirection[0];
+                int adjC = curr.getCol() + adjDirection[1];
+                if (outOfBounds(adjR, adjC)) continue;
+                cells[adjR][adjC].addNumber();
+            }
+        }
+    }
+
+    /**
+     * 게임 한 판 진행
+     * - 셀 뒤집거나 마킹표시하거나 확장하거나
+     */
+    public UserPlay.UserPlayResult playOne(UserPlay userPlay) {
+        Cell selectedCell = makeCellFrom(userPlay);
+        if (selectedCell == null) {
+            return new UserPlay.UserPlayResult(false, Game.GameStatus.RUNNING);
+        }
+        // already exposed
+        if (selectedCell.isExposed()) {
+            return new UserPlay.UserPlayResult(false, Game.GameStatus.RUNNING);
+        }
+        // marking
+        if (userPlay.isMarking()) {
+            boolean isAlreadyMarked = selectedCell.isMarked();
+            if (isAlreadyMarked) {
+                return new UserPlay.UserPlayResult(false, Game.GameStatus.RUNNING);
+            } else {
+                userPlay.markCell(selectedCell);
+                return new UserPlay.UserPlayResult(true, Game.GameStatus.RUNNING);
+            }
+        }
+        // flip
+        if (selectedCell.isBomb()) {
+            return new UserPlay.UserPlayResult(true, Game.GameStatus.LOST);
+        }
+
+        // flip Cell
+        boolean flipResult = flipCell(selectedCell);
+
+        if (selectedCell.isBlank()) {
+            expandExpose(selectedCell);
+        }
+        if (unexposedNonBombCnt == 0) {
+            return new UserPlay.UserPlayResult(true, Game.GameStatus.WON);
+        }
+
+        return new UserPlay.UserPlayResult(flipResult, Game.GameStatus.RUNNING);
+    }
+
+    /*
+    * 셀 뒤집기
+    * 노출이 안됐고, 마킹표시 안돼있어야 뒤집기 가능
+    */
+    private boolean flipCell(Cell cell) {
+        if (!cell.isExposed() && !cell.isMarked()) {
+            cell.flip();
+            unexposedNonBombCnt--;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * 빈 cell인 경우 확장 (bfs 이용)
+     * number가 0인 경우 queue에 다시 넣고 뒤집는다.
+     * number가 0 이상이거나 bomb인 경우 넣지 않고 뒤집지 않는다.
+    */
+    private void expandExpose(Cell cell) {
+        Queue<Cell> q = new LinkedList<>();
+        q.add(cell);
+        cell.flip();
+        while (!q.isEmpty()) {
+            Cell curr = q.poll();
+            for (int[] adjDir : ADJ_DIRECTIONS) {
+                int adjR = curr.getRow() + adjDir[0];
+                int adjC = curr.getCol() + adjDir[1];
+                if (outOfBounds(adjR, adjC)) continue;
+                Cell adjCell = cells[adjR][adjC];
+                if (adjCell.isBlank() && flipCell(adjCell)) {
+                    q.add(adjCell);
+                }
+            }
+        }
+    }
+
+    private Cell makeCellFrom(UserPlay userPlay) {
+        if (outOfBounds(userPlay.getRow(), userPlay.getColumn())) {
+            return null;
+        }
+        return cells[userPlay.getRow()][userPlay.getColumn()];
+    }
+
+    private boolean outOfBounds(int row, int column) {
+        return row > rowLen || row < 0 || column > colLen || column < 0;
+    }
+}

--- a/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/Board.java
+++ b/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/Board.java
@@ -104,7 +104,7 @@ public class Board {
             return new UserPlay.UserPlayResult(false, Game.GameStatus.RUNNING);
         }
         // marking
-        if (userPlay.isMarking()) {
+        if (userPlay.isMarkingPlay()) {
             boolean isAlreadyMarked = selectedCell.isMarked();
             if (isAlreadyMarked) {
                 return new UserPlay.UserPlayResult(false, Game.GameStatus.RUNNING);

--- a/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/Cell.java
+++ b/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/Cell.java
@@ -28,6 +28,9 @@ public class Cell {
         row = changedRow;
         col = changedCol;
     }
+    public void setBomb(boolean isBomb) {
+        this.isBomb = isBomb;
+    }
 
     public boolean isBlank() {
         return number == 0;

--- a/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/Cell.java
+++ b/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/Cell.java
@@ -1,0 +1,39 @@
+package com.moonz.javapractice.CrackingCodingInterview.ch7.prob10;
+
+import lombok.Getter;
+
+@Getter
+public class Cell {
+    private int row;
+    private int col;
+    private boolean isBomb; // 지뢰여부
+    private int number; // 인접 지뢰 갯수
+    private boolean isMarked = false;  // 마킹 여부
+    private boolean isExposed=  false;  // 노출 여부
+
+    public Cell (int r, int c) {
+        row = r;
+        col = c;
+    }
+
+    public void flip() {
+        isExposed = true;
+    }
+    public void mark() {
+        flip();
+        isMarked = true;
+    }
+
+    public void setRowCol(int changedRow, int changedCol) {
+        row = changedRow;
+        col = changedCol;
+    }
+
+    public boolean isBlank() {
+        return number == 0;
+    }
+
+    public void addNumber() {
+        number++;
+    }
+}

--- a/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/Game.java
+++ b/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/Game.java
@@ -1,0 +1,46 @@
+package com.moonz.javapractice.CrackingCodingInterview.ch7.prob10;
+
+import java.util.Scanner;
+
+public class Game {
+    private GameStatus gameStatus;
+    private Board board;
+
+    private void init() {
+        if (board == null) {
+            board = new Board(7, 7, 3);
+        }
+    }
+    // 사용자가 start() 호출하면서 게임 시작됨.
+    private boolean start() {
+        if (board == null) {
+            init();
+        }
+        return playGame();
+    }
+    private boolean playGame() {
+        Scanner sc = new Scanner(System.in);
+        while (gameStatus == GameStatus.RUNNING) {
+            String input = sc.nextLine();
+            UserPlay userPlay = UserPlay.fromInput(input);
+            if (userPlay == null) {
+                continue;
+            }
+            UserPlay.UserPlayResult userPlayResult = board.playOne(userPlay);
+            if (!userPlayResult.isSuccess()) {
+                System.out.println("(" + userPlay.getRow() + ", " + userPlay.getColumn() + ")은 선택 불가능한 Cell입니다.");
+                continue;
+            }
+            gameStatus = userPlayResult.getGameResultStatus();
+        }
+        sc.close();
+        return true;
+    }
+
+    public enum GameStatus {
+        WON,
+        LOST,
+        RUNNING,
+        ;
+    }
+}

--- a/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/UserPlay.java
+++ b/Java-Practice/src/main/java/com/moonz/javapractice/CrackingCodingInterview/ch7/prob10/UserPlay.java
@@ -1,0 +1,43 @@
+package com.moonz.javapractice.CrackingCodingInterview.ch7.prob10;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+@AllArgsConstructor
+@Getter
+public class UserPlay {
+    private int row;
+    private int column;
+    private boolean isMarkingPlay;  // 마크 클릭인지 여부
+
+    /**
+     * 해당 셀 마킹 표시
+     */
+    void markCell(Cell cell) {
+        cell.mark();
+    }
+
+    /**
+     * 사용자 입력값을 UserPlay로 변환
+     * ex) 1,2 -> 클릭 1열 2행
+     */
+    public static UserPlay fromInput (String input) {
+        if (input.length() <= 0) {
+            return null;
+        }
+        String[] split = input.split(",");
+        int row = Integer.parseInt(split[0]);
+        int col = Integer.parseInt(split[1]);
+        return new UserPlay(row, col, false);
+    }
+
+    @Getter
+    public static class UserPlayResult {
+        private final boolean success;
+        private final Game.GameStatus gameResultStatus;
+
+        public UserPlayResult (boolean success, Game.GameStatus gameResultStatus) {
+            this.success = success;
+            this.gameResultStatus = gameResultStatus;
+        }
+    }
+}


### PR DESCRIPTION
## 문제
지뢰찾기는 NXN 격자판에 숨겨진 B개의 지뢰를 찾는 고전적인 컴퓨터 게임이다. 지뢰가 없는 셀(cell)에는 아무것도 적혀 있지 않거나 인접한 여덟 방향에 숨겨진 지뢰의 개수가 적혀 있다. 플레이어는 각 셀을 확인해 볼 수 있는데, 확인한 셀에 지뢰가 있다면 그 즉시 게임에서 진다. 확인한 셀에 숫자가 적혀 있다면 그 값이 공개된다. 해당 셀이 비어 있다면 인접한 비어 있는 셀(숫자로 둘러싸인 셀을 만나기 전까지) 또한 모두 공개된다. 지뢰가 없는 셀을 전부 공개된 상태로 바꿔 놓으면 플레이어가 이긴다. 지뢰가 있을 것 같은 위치에 깃발을 꽂아 표시해 둘 수 있는데, 깃발을 꽂는 것은 게임에 아무런 영향을 미치지 않는다. 실수로 잘못 클릭하는 상황을 방지하기 위한 기능일 뿐이다(이 게임에 대해 잘 모른다면, 미리 몇 번 해보길 바란다).

## 필요한 컴포넌트
**사용자 움직임 UserPlay**
- win : 지뢰를 제외한 모든 셀을 open
- lost : 지뢰 open
- 진행 : 지뢰를 제외한 cell open (빈칸, 숫자칸)
- 행동 : 셀 뒤집기 (마킹 or 선택)

**보드 Board**
- 2차원 셀
- 지뢰 갯수
- 지뢰를 제외한 총 갯수
- 생성자 메서드에서 보드판과 지뢰 셀과 숫자 셀에 대한 초기화 필요 (init, random)

**셀 Cell**
- 열 row
- 행 col
- 마킹됐는지 여부
- 지뢰인지
- 오픈됐는지 여부
- 숫자 (주위 지뢰 갯수)

**게임 Game**
- 게임 진행 상태
- 보드
- 행동 :  게임 시작 (UserPlay 이용)